### PR TITLE
Improve user interface (mainly for cancel behavior)

### DIFF
--- a/autoload/giti.vim
+++ b/autoload/giti.vim
@@ -27,7 +27,12 @@ function! giti#system_with_specifics(param)"{{{
     call giti#print('Not a git repository')
     call giti#print('Specify directory of git repository (and change current directory of this window)')
     call giti#print('current  : ' . getcwd())
-    call giti#execute(printf('lcd %s', giti#input('change to: ', getcwd())))
+    let new_directory = giti#input('change to: ', getcwd())
+    if new_directory == ''
+      call giti#print('cacneled')
+      return
+    endif
+    call giti#execute(printf('lcd %s', new_directory))
     return giti#system_with_specifics(a:param)
   endif
 

--- a/autoload/giti.vim
+++ b/autoload/giti.vim
@@ -29,7 +29,8 @@ function! giti#system_with_specifics(param)"{{{
     call giti#print('current  : ' . getcwd())
     let new_directory = giti#input('change to: ', getcwd())
     if new_directory == ''
-      call giti#print('cacneled')
+      " Note 'redraw' is required to prevent 'Press ENTER or type...' message
+      redraw | call giti#print('cacneled')
       return
     endif
     call giti#execute(printf('lcd %s', new_directory))
@@ -40,7 +41,8 @@ function! giti#system_with_specifics(param)"{{{
 
   if exists('a:param.with_confirm') && a:param.with_confirm
     if !s:is_confirmed(a:param)
-      call giti#print('canceled')
+      " Note 'redraw' is required to prevent 'Press ENTER or type...' message
+      redraw | call giti#print('canceled')
       return
     endif
   endif

--- a/autoload/giti/branch.vim
+++ b/autoload/giti/branch.vim
@@ -7,15 +7,25 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! giti#branch#list()"{{{
+  let result = giti#system('branch')
+  if type(result) == 0
+    " canceled
+    return []
+  endif
   return map(
-\   split(giti#system('branch'), '\n'),
+\   split(result, '\n'),
 \   's:build_branch_data(v:val)'
 \ )
 endfunction"}}}
 
 function! giti#branch#list_all()"{{{
+  let result = giti#system('branch -a')
+  if type(result) == 0
+    " canceled
+    return []
+  endif
   return map(
-\   split(giti#system('branch -a'), '\n'),
+\   split(result, '\n'),
 \   's:build_branch_data(v:val)'
 \ )
 endfunction"}}}
@@ -26,9 +36,14 @@ function! giti#branch#current_name()"{{{
 endfunction"}}}
 
 function! giti#branch#current()"{{{
+  let result = giti#system('branch -a')
+  if type(result) == 0
+    " canceled
+    return []
+  endif
   let branches = filter(
 \   map(
-\     split(giti#system('branch -a'), '\n'),
+\     split(result, '\n'),
 \     's:build_branch_data(v:val)'
 \   ),
 \   'v:val.is_current'

--- a/autoload/giti/config.vim
+++ b/autoload/giti/config.vim
@@ -14,10 +14,18 @@ function! giti#config#run()"{{{
 endfunction"}}}
 
 function! giti#config#list()"{{{
+  " Note:
+  "   The first s:get_list returl value should be checked while user might
+  "   cancel the process (and then the return value will be 0)
+  let global = s:get_list({'location': 'global'})
+  if type(global) == 0
+    " canceled
+    return []
+  endif
   return extend(
 \   extend(
 \     map(
-\       s:get_list({'location' : 'global'}), '
+\       global, '
 \       s:build_config_data({
 \         "line"     : v:val,
 \         "location" : "global"
@@ -104,6 +112,9 @@ function! s:get_list(param)"{{{
 \ })
   if giti#has_shell_error()
     return []
+  elseif type(res) == 0
+    " operation has canceled (thus return 0)
+    return
   endif
   return split(res, '\n')
 endfunction"}}}

--- a/autoload/giti/log.vim
+++ b/autoload/giti/log.vim
@@ -49,6 +49,10 @@ function! s:get_list(param)"{{{
 \   'log -%d --graph --date=default --pretty=format:"%s" %s',
 \   line_count, s:pretty_format, file
 \ ))
+  if type(res) == 0
+    " the operation has canceled
+    return []
+  endif
   return split(res, '\n')
 endfunction"}}}
 

--- a/autoload/giti/remote.vim
+++ b/autoload/giti/remote.vim
@@ -7,7 +7,12 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! giti#remote#show()"{{{
-  return split(giti#system('remote show'), "\n")
+  let ret = giti#system('remote show')
+  if type(ret) == 0
+    " the operation has canceled
+    return []
+  endif
+  return split(ret, "\n")
 endfunction"}}}
 
 function! giti#remote#show_verbose()"{{{

--- a/autoload/giti/status.vim
+++ b/autoload/giti/status.vim
@@ -27,6 +27,10 @@ endfunction"}}}
 
 function! s:get_list()
   let res = giti#system('status -s')
+  if type(res) == 0
+    " the operation has canceled
+    return []
+  endif
   return split(res, '\n')
 endfunction
 


### PR DESCRIPTION
便利に使わせていただいています。有末です。

vim-unite-giti のソースをgitレポジトリではない場所で誤って開いた場合などに、処理がキャンセルできなかった（gitレポジトリを指定しろと無限回聞かれる）ため、下記のような変更を施しました。

1. `giti#system_with_specifics` でユーザーが`<Esc>`を押した場合は処理をキャンセルする
2. キャンセル処理が加わったので、キャンセル後でも正しく空candidatesを返すように幾つかの関数を修正

出来ればテストまで揃えてPRを送りたかったのですが、どのように記載すれば不透明だったためテストなしで送っています。
お暇なときにでも、ご確認ください。

I did

1. Cancel the procedure when user hit `Escape` in `giti#system_with_specifics` function
2. Fix several functions to return an empty list when `giti#system_with_specifics` returned 0 (when user has canceled the procedure)