### PR TITLE
Fix fold comments

### DIFF
--- a/autoload/unite/kinds/giti.vim
+++ b/autoload/unite/kinds/giti.vim
@@ -35,7 +35,7 @@ endfunction "}}}
 
 function! s:to_define_func(command) "{{{
   return 'unite#kinds#giti#' . a:command . '#define'
-endfunction}}}
+endfunction "}}}
 
 function! s:add_rm_action_on_file_kind() "{{{
   let git_rm = {

--- a/autoload/unite/sources/giti.vim
+++ b/autoload/unite/sources/giti.vim
@@ -48,7 +48,7 @@ endfunction "}}}
 
 function! s:to_define_func(command) "{{{
   return 'unite#sources#giti#' . a:command . '#define'
-endfunction}}}
+endfunction "}}}
 " }}}
 
 " context getter {{{


### PR DESCRIPTION
I'm not sure why now it's suddenly happening, but I got syntax errors with `endfunction}}}`.
Probably it's due to Vim update.